### PR TITLE
perf: build設定の最適化

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,13 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-transform-modules-commonjs"]
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": "last 2 Chrome version",
+        "useBuiltIns": "usage",
+        "corejs": "3.6"
+      }
+    ], 
+    "@babel/preset-react"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
     "@babel/node": "^7.8.7",
-    "@babel/plugin-transform-modules-commonjs": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-react": "^7.9.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.28",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "clean": "rimraf dist",
     "build": "npm-run-all clean build:css build:webpack-with-mock-data",
     "build:css": "postcss src/app.css -d dist",
-    "build:webpack": "cross-env NODE_ENV=development webpack --config webpack.config.js",
-    "build:webpack-with-mock-data": "cross-env USE_MOCK_DATA=true NODE_ENV=development webpack --config webpack.config.js",
+    "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.config.js",
+    "build:webpack-with-mock-data": "cross-env USE_MOCK_DATA=true NODE_ENV=production webpack --config webpack.config.js",
     "fmt": "prettier --write 'src/**/*.{js,css}'",
     "reg-suit": "reg-suit run",
     "serve": "nodemon --exec babel-node lib/server.js"
@@ -18,6 +18,7 @@
     "autoprefixer": "^9.7.4",
     "babel-loader": "^8.1.0",
     "cross-env": "^7.0.2",
+    "file-loader": "^6.2.0",
     "html-webpack-plugin": "^3.2.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.8",

--- a/src/foundation/polyfills.js
+++ b/src/foundation/polyfills.js
@@ -1,2 +1,1 @@
-import 'core-js';
 import 'regenerator-runtime/runtime';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,8 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const NODE_ENV = process.env.NODE_ENV
+
 module.exports = {
   entry: path.resolve(__dirname, 'src', 'app.js'),
 
@@ -19,7 +21,7 @@ module.exports = {
 
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
       'process.env.USE_MOCK_DATA': JSON.stringify(process.env.USE_MOCK_DATA),
     }),
     new HtmlWebpackPlugin({
@@ -33,6 +35,7 @@ module.exports = {
     rules: [
       {
         test: /\.m?jsx?$/,
+        exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
         },
@@ -41,6 +44,9 @@ module.exports = {
         test: /\.(png|svg|jpe?g|gif)$/,
         use: {
           loader: 'url-loader',
+          options: {
+            limit: 8192,
+          },
         },
       },
     ],
@@ -48,7 +54,7 @@ module.exports = {
 
   target: 'web',
 
-  devtool: 'inline-source-map',
+  devtool: NODE_ENV === 'production' ? false : 'inline-source-map',
 
-  mode: 'none',
+  mode: NODE_ENV,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,8 @@ module.exports = {
           loader: 'url-loader',
           options: {
             limit: 8192,
+            outputPath: 'images',
+            publicPath: '/images'
           },
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/json-schema@^7.0.6":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
 "@types/lodash@^4.14.161":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
@@ -1239,6 +1244,11 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
+ajv-keywords@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
 ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.0:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
@@ -1249,7 +1259,7 @@ ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.12.3:
+ajv@^6.12.3, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3251,6 +3261,14 @@ figures@^3.0.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-loader@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
+  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -6991,6 +7009,15 @@ schema-utils@^2.6.5:
   dependencies:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
+
+schema-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
+  integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
効果があったもの(降順)
- devtoolをproduction時にはfalseに(inline-source-mapはファイルサイズがでかすぎる)
- modeをproductionに
- NODE_ENVがproductionになると各種ライブラリがある程度最適化される？
- file_loaderを使うことでファイルサイズのでかい画像を切り出し(元はbase64で埋め込まれていた)